### PR TITLE
v0.4.0: adding a customer error handler option feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+.ruby-version
+.rbenv-gemsets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.0
+
+* Handle stoplight custom error handlers (see [issue #3](https://github.com/textmaster/faraday_middleware-circuit_breaker/issues/3))
+
 # 0.3.0
 
 * Handles stoplight data store

--- a/lib/faraday_middleware/circuit_breaker/middleware.rb
+++ b/lib/faraday_middleware/circuit_breaker/middleware.rb
@@ -24,6 +24,7 @@ module FaradayMiddleware
         .with_cool_off_time(option_set.timeout)
         .with_threshold(option_set.threshold)
         .with_fallback { |e| option_set.fallback.call(env, e) }
+        .with_error_handler { |err, handler| option_set.error_handler.call(err, handler) }
         .run
       end
 

--- a/lib/faraday_middleware/circuit_breaker/option_set.rb
+++ b/lib/faraday_middleware/circuit_breaker/option_set.rb
@@ -6,9 +6,9 @@ module FaradayMiddleware
   module CircuitBreaker
     class OptionSet
 
-      VALID_OPTIONS = %w(timeout threshold fallback notifiers data_store)
+      VALID_OPTIONS = %w(timeout threshold fallback notifiers data_store, error_handler)
 
-      attr_accessor :timeout, :threshold, :fallback, :notifiers, :data_store
+      attr_accessor :timeout, :threshold, :fallback, :notifiers, :data_store, :error_handler
 
       def initialize(options = {})
         @timeout    = options[:timeout] || 60.0
@@ -16,6 +16,7 @@ module FaradayMiddleware
         @fallback   = options[:fallback] || proc { Faraday::Response.new(status: 503, response_headers: {}) }
         @notifiers  = options[:notifiers] || {}
         @data_store = options[:data_store] || proc { Stoplight::Light.default_data_store }
+        @error_handler = options[:error_handler] || Stoplight::Default::ERROR_HANDLER
       end
 
       def self.validate!(options)

--- a/lib/faraday_middleware/circuit_breaker/version.rb
+++ b/lib/faraday_middleware/circuit_breaker/version.rb
@@ -1,5 +1,5 @@
 module FaradayMiddleware
   module CircuitBreaker
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
# 0.4.0

* Handle stoplight custom error handlers (see [issue #3](https://github.com/textmaster/faraday_middleware-circuit_breaker/issues/3))
