### PR TITLE
Change stoplight to use base url instead of full url

### DIFF
--- a/lib/faraday_middleware/circuit_breaker/middleware.rb
+++ b/lib/faraday_middleware/circuit_breaker/middleware.rb
@@ -17,7 +17,8 @@ module FaradayMiddleware
       end
 
       def call(env)
-        Stoplight(env.url.to_s) do
+        base_url = URI.join(env.url, '/')
+        Stoplight(base_url.to_s) do
           @app.call(env)
         end
         .with_cool_off_time(option_set.timeout)


### PR DESCRIPTION
Based on finding from my colleagues, cc @sayap and Andri

Originally, given connections to:
- http://www.foocorp.com/api/v1/users?query=foobar
- http://www.foocorp.com/api/v1/users?query=barbaz

It will:
- When `query=foobar` is tripped, the next connection to `query=barbaz` won't be tripped. In most cases the host is down and we want to trip it
- Populate a lot of keys for `states` in stoplight data store. When there are a huge (unlimited) combination of query string, it can "overload" the data store

This commit changes the url identifier to use the base url

Taken from: https://makandracards.com/makandra/12121-ruby-extract-the-hostname-from-a-url:
```
url = 'http://www.foocorp.com:33546/foo/bar?query=foobar#hash'
URI.join url, '/'
# => http://www.foocorp.com:33546/
```

This changes might be a **breaking changes** if people expect the stoplight url to be unique for full url. I think this is a bug though

PS:
I saw a PR on https://github.com/textmaster/faraday_middleware-circuit_breaker/pull/4, will bump my version if that PR got merged earlier