### PR TITLE
Add http response handler

### DIFF
--- a/lib/faraday_middleware/circuit_breaker/middleware.rb
+++ b/lib/faraday_middleware/circuit_breaker/middleware.rb
@@ -19,7 +19,7 @@ module FaradayMiddleware
       def call(env)
         base_url = URI.join(env.url, '/')
         Stoplight(base_url.to_s) do
-          @app.call(env)
+          option_set.response_handler.call(@app.call(env))
         end
         .with_cool_off_time(option_set.timeout)
         .with_threshold(option_set.threshold)

--- a/lib/faraday_middleware/circuit_breaker/option_set.rb
+++ b/lib/faraday_middleware/circuit_breaker/option_set.rb
@@ -6,9 +6,9 @@ module FaradayMiddleware
   module CircuitBreaker
     class OptionSet
 
-      VALID_OPTIONS = %w(timeout threshold fallback notifiers data_store error_handler)
+      VALID_OPTIONS = %w(timeout threshold fallback notifiers data_store error_handler response_handler)
 
-      attr_accessor :timeout, :threshold, :fallback, :notifiers, :data_store, :error_handler
+      attr_accessor :timeout, :threshold, :fallback, :notifiers, :data_store, :error_handler, :response_handler
 
       def initialize(options = {})
         @timeout    = options[:timeout] || 60.0
@@ -17,6 +17,7 @@ module FaradayMiddleware
         @notifiers  = options[:notifiers] || {}
         @data_store = options[:data_store] || proc { Stoplight::Light.default_data_store }
         @error_handler = options[:error_handler] || Stoplight::Default::ERROR_HANDLER
+        @response_handler = options[:response_handler] || ->(response) { response }
       end
 
       def self.validate!(options)


### PR DESCRIPTION
Hi,

Since the existing implementation only rely on error/exception for adding Stoplight failures so this PR will add ability based on HTTP response through it's handler. 
For example if the response is returning 502 or 503 then it will also as decision for switching the light (green to red). 

The scenario as i added in spec file.