### PR TITLE
Relax version requirement for Stoplight dependency to include 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Relaxed version requirement for Stoplight to include 3.0
 
 ## [0.4.1]
 ### Fixed

--- a/faraday_middleware-circuit_breaker.gemspec
+++ b/faraday_middleware-circuit_breaker.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'faraday', '>= 0.9', '< 2.0'
-  spec.add_dependency 'stoplight', '~> 2.1'
+  spec.add_dependency 'stoplight', '>= 2.1', '< 4.0'
 
   spec.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
Stoplight relieved a redis pipeline deprecation in 3.0 that is very noisy. We are unable to upgrade our stoplight dependency until this version is relaxed.

https://github.com/bolshakov/stoplight/releases/tag/v3.0.0