### PR TITLE
Relax version requirement for Faraday dependency to include 2.x

### DIFF
--- a/faraday_middleware-circuit_breaker.gemspec
+++ b/faraday_middleware-circuit_breaker.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday', '>= 0.9', '< 2.0'
+  spec.add_dependency 'faraday', '>= 0.9', '< 3.0'
   spec.add_dependency 'stoplight', '>= 2.1', '< 4.0'
 
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
Version 2 of Faraday was released [just over 2 years ago](https://github.com/lostisland/faraday/releases/tag/v2.0.0), so I think it is time to update :)

Luckily everything seems to work out of the box, tested with Faraday 2.8.1 on Ruby 2.7.8 and 3.2.2

On 2.7.6
```
faraday_middleware-circuit_breaker|faraday2 ⇒ rake spec
~/.rbenv/versions/2.7.6/bin/ruby -I~/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rspec-support-3.13.0/lib:~/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rspec-core-3.13.0/lib ~/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rspec-core-3.13.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

FaradayMiddleware::CircuitBreaker
  is expected to eq 200
  is expected to eq 500
  is expected to eq 503
  is expected not to raise Exception
  is expected to eq 503
  is expected not to raise Exception
  is expected to eq 503
  on failure
    calls fallback
    calls error handler
  on failure with different query string
    should still tripped

Finished in 0.01721 seconds (files took 0.22905 seconds to load)
10 examples, 0 failures
```

On 3.2.2
```
faraday_middleware-circuit_breaker|faraday2 ⇒ rake spec
~/.rbenv/versions/3.2.2/bin/ruby -I~/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-support-3.13.0/lib:~/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.13.0/lib ~/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/rspec-core-3.13.0/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb

FaradayMiddleware::CircuitBreaker
  is expected to eq 200
  is expected to eq 500
  is expected to eq 503
  is expected not to raise Exception
  is expected to eq 503
  is expected not to raise Exception
  is expected to eq 503
  on failure
    calls fallback
    calls error handler
  on failure with different query string
    should still tripped

Finished in 0.03023 seconds (files took 0.32571 seconds to load)
10 examples, 0 failures
```