### PR TITLE
Allow for a custom stoplight key logic

### DIFF
--- a/lib/faraday_middleware/circuit_breaker/middleware.rb
+++ b/lib/faraday_middleware/circuit_breaker/middleware.rb
@@ -18,7 +18,7 @@ module FaradayMiddleware
 
       def call(env)
         base_url = option_set.cache_key_generator.call(env.url)
-        Stoplight(base_url.to_s) do
+        Stoplight(base_url) do
           @app.call(env)
         end
         .with_cool_off_time(option_set.timeout)

--- a/lib/faraday_middleware/circuit_breaker/middleware.rb
+++ b/lib/faraday_middleware/circuit_breaker/middleware.rb
@@ -17,7 +17,7 @@ module FaradayMiddleware
       end
 
       def call(env)
-        base_url = URI.join(env.url, '/')
+        base_url = option_set.cache_key_generator.call(env.url)
         Stoplight(base_url.to_s) do
           @app.call(env)
         end

--- a/lib/faraday_middleware/circuit_breaker/option_set.rb
+++ b/lib/faraday_middleware/circuit_breaker/option_set.rb
@@ -6,9 +6,9 @@ module FaradayMiddleware
   module CircuitBreaker
     class OptionSet
 
-      VALID_OPTIONS = %w(timeout threshold fallback notifiers data_store error_handler)
+      VALID_OPTIONS = %w(timeout threshold fallback notifiers data_store error_handler cache_key_generator)
 
-      attr_accessor :timeout, :threshold, :fallback, :notifiers, :data_store, :error_handler
+      attr_accessor :timeout, :threshold, :fallback, :notifiers, :data_store, :error_handler, :cache_key_generator
 
       def initialize(options = {})
         @timeout    = options[:timeout] || 60.0
@@ -17,6 +17,7 @@ module FaradayMiddleware
         @notifiers  = options[:notifiers] || {}
         @data_store = options[:data_store] || proc { Stoplight::Light.default_data_store }
         @error_handler = options[:error_handler] || Stoplight::Default::ERROR_HANDLER
+        @cache_key_generator = options[:cache_key_generator] || ->(url) { URI.join(url, '/') }
       end
 
       def self.validate!(options)

--- a/lib/faraday_middleware/circuit_breaker/option_set.rb
+++ b/lib/faraday_middleware/circuit_breaker/option_set.rb
@@ -17,7 +17,7 @@ module FaradayMiddleware
         @notifiers  = options[:notifiers] || {}
         @data_store = options[:data_store] || proc { Stoplight::Light.default_data_store }
         @error_handler = options[:error_handler] || Stoplight::Default::ERROR_HANDLER
-        @cache_key_generator = options[:cache_key_generator] || ->(url) { URI.join(url, '/') }
+        @cache_key_generator = options[:cache_key_generator] || ->(url) { URI.join(url, '/').to_s }
       end
 
       def self.validate!(options)

--- a/spec/faraday_middleware/circuit_breaker_spec.rb
+++ b/spec/faraday_middleware/circuit_breaker_spec.rb
@@ -86,7 +86,7 @@ describe FaradayMiddleware::CircuitBreaker do
       lambda do |url|
         base_url = url.clone
         base_url.fragment = base_url.query = nil
-        base_url
+        base_url.to_s
       end
     end
 

--- a/spec/faraday_middleware/circuit_breaker_spec.rb
+++ b/spec/faraday_middleware/circuit_breaker_spec.rb
@@ -80,4 +80,22 @@ describe FaradayMiddleware::CircuitBreaker do
 
   end
 
+  describe 'with a different cache key generator' do
+    let(:threshold) { 3 }
+    let(:cache_key_generator) do
+      lambda do |url|
+        base_url = url.clone
+        base_url.fragment = base_url.query = nil
+        base_url
+      end
+    end
+
+    it 'should not trip when the new key differs' do
+      conn = connection(threshold: threshold, cache_key_generator: cache_key_generator)
+      threshold.times { conn.get('/query?key=error') }
+      expect(conn.get('/query?key=success').status).to eq(503)
+      expect(conn.get('/success').status).to eq(200)
+    end
+  end
+
 end


### PR DESCRIPTION
This is a followup on #7. I totally understand why it was done that way, and in most cases it does make sense, however for my own usecase where we have a single domain serving multiple services, if a single service misbehaves then the entire API goes down and it's not ideal. To illustrate:
- `https://api.mydomain.com/users` is served by the microservice A
- `https://api.mydomain.com/orders` is served by the microservice B
- `https://api.mydomain.com/products` is served by the microservice C

If something happens with microservice B, I still want `/users` and `/products` to be queried as usual.
@gottfrois @timbogit 
 This is just a proposal of a suggestion on how to address this, feel free to suggest any other way and I'll give it a crack.

I'm sure everyone's use case will vary slightly, so the idea here is to allow to pass a lambda in the config that will turn the URI resource into whatever key will be use by spotlight, defaulting to this gem's current behaviour. In the test I have added what I might do for my own service (use the full path minus query params), but that way anyone can do whatever they need.

Passing the tests:
```
FaradayMiddleware::CircuitBreaker
  is expected to eq 200
  is expected to eq 500
  is expected to eq 503
  is expected not to raise Exception
  is expected to eq 503
  is expected not to raise Exception
  is expected to eq 503
  on failure
    calls fallback
    calls error handler
  on failure with different query string
    should still tripped
  with a different cache key generator
    should not trip when the new key differs

Finished in 0.0269 seconds (files took 0.25528 seconds to load)
11 examples, 0 failures
```